### PR TITLE
Bump airtap-sauce to 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -613,12 +613,13 @@
       }
     },
     "airtap-sauce": {
-      "version": "github:jzombie/sauce#9223e884065dc1f4133dabd143bf282aabb8e97c",
-      "from": "github:jzombie/sauce#feature/github-actions-build",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/airtap-sauce/-/airtap-sauce-1.1.2.tgz",
+      "integrity": "sha512-0qbGYxZ7hOZ8Tv7MZ8Q4Vg4LTbYgDOsLbK8x/cH6E+FFMMXPDBO5lPHBtuB14FxEFxUGAD6mybfmwyK8NxJOZA==",
       "dev": true,
       "requires": {
         "abstract-browser": "^1.0.0",
-        "airtap-sauce-browsers": "^0.2.1",
+        "airtap-sauce-browsers": "^0.2.2",
         "browser-provider": "^1.1.0",
         "build-number": "^1.0.0",
         "debug": "^4.1.1",
@@ -630,9 +631,9 @@
       }
     },
     "airtap-sauce-browsers": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/airtap-sauce-browsers/-/airtap-sauce-browsers-0.2.1.tgz",
-      "integrity": "sha512-n19lfV1cnXoVGfWiKkYzK1OsXK70Sw4RWR+YPNUMls05ZNVLXsODQpWhVpZwGOv58uZKzki3Mbu0r4FFbEXq+Q==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/airtap-sauce-browsers/-/airtap-sauce-browsers-0.2.2.tgz",
+      "integrity": "sha512-4UJHyVaamfbgSLYWrK5bJgSNVdBYdEeEvp4VjhNgiemrN0xfNrcBSiAHzglcK3qeGx/iYbTDPDM9VZlpVA/tQg==",
       "dev": true,
       "requires": {
         "browser-names": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "airtap": "^4.0.3",
     "airtap-manual": "^1.0.0",
-    "airtap-sauce": "github:jzombie/sauce#feature/github-actions-build",
+    "airtap-sauce": "^1.1.2",
     "babel-minify": "^0.5.1",
     "bowser": "^2.11.0",
     "browserify": "^17.0.0",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x ] Other, please explain:

Re-using upstream airtap-sauce after 1.1.2 fix for adding GitHub Actions build number reporting
